### PR TITLE
URL Cleanup

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -2,7 +2,7 @@
 
 A build tool for Erlang that just works.
 
-http://erlang.mk/ - http://erlang.mk/guide/[User guide]
+https://erlang.mk/ - https://erlang.mk/guide/[User guide]
 
 Embrace the power and simplicity of Makefiles.
 
@@ -11,8 +11,8 @@ PROJECT = webchat
 DEPS = cowboy
 include erlang.mk
 
-http://erlang.mk/guide/getting_started.html[Get started]
+https://erlang.mk/guide/getting_started.html[Get started]
 
 Tested and supported on
-http://erlang.mk/guide/installation.html#_on_unix[Linux, FreeBSD, OSX]
-and http://erlang.mk/guide/installation.html#_on_windows[Windows].
+https://erlang.mk/guide/installation.html#_on_unix[Linux, FreeBSD, OSX]
+and https://erlang.mk/guide/installation.html#_on_windows[Windows].

--- a/README.legacy.md
+++ b/README.legacy.md
@@ -2,7 +2,7 @@ Old Erlang.mk documentation
 ===========================
 
 This documentation reminds here until it gets moved to the
-official documentation on http://erlang.mk/guide/.
+official documentation on https://erlang.mk/guide/.
 
 Extending Erlang.mk
 -------------------
@@ -102,7 +102,7 @@ There are a number of optional configuration parameters:
 * `ESCRIPT_SHEBANG` for the line used by your shell to start `escript`
 * `ESCRIPT_STATIC` for non-beam directories to be included as well
 
-Refer to http://www.erlang.org/doc/man/escript.html for
+Refer to https://www.erlang.org/doc/man/escript.html for
 more information on `escript` functionality in general.
 
 Triq plugin

--- a/doc/src/guide/app.asciidoc
+++ b/doc/src/guide/app.asciidoc
@@ -100,7 +100,7 @@ information about what releases are and how they are generated.
 === Application resource file
 
 When building your application, Erlang.mk will generate the
-http://www.erlang.org/doc/man/app.html[application resource file].
+https://www.erlang.org/doc/man/app.html[application resource file].
 This file is mandatory for all Erlang applications and is
 found in 'ebin/$(PROJECT).app'.
 
@@ -255,7 +255,7 @@ the build process and the resulting files.
 
 `ERLC_OPTS` can be used to pass some options to `erlc`, the Erlang
 compiler. Erlang.mk does not restrict any option. Please refer to
-the http://www.erlang.org/doc/man/erlc.html[erlc Manual] for the
+the https://www.erlang.org/doc/man/erlc.html[erlc Manual] for the
 full list.
 
 By default, Erlang.mk will set the following options:

--- a/doc/src/guide/common_test.asciidoc
+++ b/doc/src/guide/common_test.asciidoc
@@ -7,7 +7,7 @@ Test suites.
 
 === Writing tests
 
-The http://www.erlang.org/doc/apps/common_test/write_test_chapter.html[Common Test user guide]
+The https://www.erlang.org/doc/apps/common_test/write_test_chapter.html[Common Test user guide]
 is the best place to learn how to write tests. Erlang.mk
 requires that file names for test suites end with '_SUITE.erl'
 and that the files be located in the '$(TEST_DIR)' directory.
@@ -17,7 +17,7 @@ This defaults to 'test/'.
 
 The `CT_OPTS` variable allows you to set extra Common Test
 options. Options are documented in the
-http://www.erlang.org/doc/apps/common_test/run_test_chapter.html[Common Test user guide].
+https://www.erlang.org/doc/apps/common_test/run_test_chapter.html[Common Test user guide].
 You can use it to set Common Test hooks, for example:
 
 [source,make]

--- a/doc/src/guide/contributing.asciidoc
+++ b/doc/src/guide/contributing.asciidoc
@@ -74,7 +74,7 @@ Packages can be added to the index using the `pkg_add.sh` script.
 $ git clone https://github.com/$YOURUSERNAME/erlang.mk
 $ cd erlang.mk
 $ ./pkg_add.sh cowboy git https://github.com/ninenines/cowboy 1.0.0
-  http://ninenines.eu "Small, fast and modular HTTP server."
+  https://ninenines.eu "Small, fast and modular HTTP server."
 $ git push origin master
 ----
 

--- a/doc/src/guide/edoc.asciidoc
+++ b/doc/src/guide/edoc.asciidoc
@@ -6,14 +6,14 @@ that generates documentation based on comments found in modules.
 
 === Writing EDoc comments
 
-The http://www.erlang.org/doc/apps/edoc/chapter.html[EDoc user guide]
+The https://www.erlang.org/doc/apps/edoc/chapter.html[EDoc user guide]
 explains everything you need to know about EDoc comments.
 
 === Configuration
 
 The `EDOC_OPTS` variable allows you to specify additional
 EDoc options. Options are documented in the
-http://www.erlang.org/doc/man/edoc.html#run-2[EDoc manual].
+https://www.erlang.org/doc/man/edoc.html#run-2[EDoc manual].
 
 A common use for this variable is to enable Markdown in doc
 comments, using the `edown` application:

--- a/doc/src/guide/eunit.asciidoc
+++ b/doc/src/guide/eunit.asciidoc
@@ -7,7 +7,7 @@ discovery and running of unit tests.
 
 === Writing tests
 
-The http://www.erlang.org/doc/apps/eunit/chapter.html[EUnit user guide]
+The https://www.erlang.org/doc/apps/eunit/chapter.html[EUnit user guide]
 is the best place to learn how to write tests. Of note is
 that all functions ending with `_test` or `_test_` will be
 picked up as EUnit test cases.
@@ -54,7 +54,7 @@ perform a normal build after running tests, and vice versa.
 
 The `EUNIT_OPTS` variable allows you to specify additional
 EUnit options. Options are documented in the
-http://www.erlang.org/doc/man/eunit.html#test-2[EUnit manual].
+https://www.erlang.org/doc/man/eunit.html#test-2[EUnit manual].
 At the time of writing, the only available option is `verbose`:
 
 [source,make]

--- a/doc/src/guide/external_plugins_list.asciidoc
+++ b/doc/src/guide/external_plugins_list.asciidoc
@@ -12,7 +12,7 @@ http://efene.org/[Efene] is an alternative language for the BEAM.
 === elixir.mk
 
 An https://github.com/botsunit/elixir.mk[Elixir plugin] for
-Erlang.mk. http://elixir-lang.org/[Elixir] is an alternative
+Erlang.mk. https://elixir-lang.org/[Elixir] is an alternative
 language for the BEAM.
 
 === elvis.mk
@@ -51,7 +51,7 @@ language for the BEAM.
 
 A https://github.com/botsunit/mix.mk[Mix plugin] for Erlang.mk,
 to generate a compatible configuration file for
-http://elixir-lang.org/getting-started/mix-otp/introduction-to-mix.html[Mix].
+https://elixir-lang.org/getting-started/mix-otp/introduction-to-mix.html[Mix].
 
 === reload.mk
 

--- a/doc/src/guide/installation.asciidoc
+++ b/doc/src/guide/installation.asciidoc
@@ -73,13 +73,13 @@ MSYS2 in order to use Erlang.mk.
 
 Erlang.mk requires Erlang/OTP to be installed. The OTP team
 provides binaries of Erlang/OTP for all major and minor releases,
-available from the http://www.erlang.org/download.html[official download page].
+available from the https://www.erlang.org/download.html[official download page].
 It is recommended that you use the 64-bit installer unless
 technically impossible. Please follow the instructions from
 the installer to complete the installation.
 
 The OTP team also provides a short guide to
-http://www.erlang.org/download.html[installing Erlang/OTP on Windows]
+https://www.erlang.org/download.html[installing Erlang/OTP on Windows]
 if you need additional references.
 
 You can install Erlang/OTP silently using the `/S` switch
@@ -95,7 +95,7 @@ The only supported environment on Windows is MSYS2. MSYS2 is
 a lightweight Unix-like environment for Windows that comes
 with the Arch Linux package manager, `pacman`.
 
-The MSYS2 project provides a http://msys2.github.io[one click installer]
+The MSYS2 project provides a https://msys2.github.io[one click installer]
 and instructions to set things up post-installation.
 
 It is currently not possible to use the installer silently.
@@ -104,7 +104,7 @@ be used in lieu of the installer. The archive however requires
 _7zip_ to decompress it.
 
 First, download the
-http://sourceforge.net/projects/msys2/files/Base/x86_64/msys2-base-x86_64-20150512.tar.xz/download[MSYS2 base archive]
+https://sourceforge.net/projects/msys2/files/Base/x86_64/msys2-base-x86_64-20150512.tar.xz/download[MSYS2 base archive]
 and extract it under 'C:\'. Assuming you downloaded the
 archive as 'msys2.tar.xz' and put it in 'C:\', you can
 use the following commands to extract it:

--- a/doc/src/guide/kerl.asciidoc
+++ b/doc/src/guide/kerl.asciidoc
@@ -22,7 +22,7 @@ there also was an `OTP_R16B03-1` release that fixed a
 critical issue in the initial release.
 
 The README file for all official Erlang/OTP releases can
-be found on http://www.erlang.org/downloads[erlang.org].
+be found on https://www.erlang.org/downloads[erlang.org].
 To obtain information about patch releases when they are
 released you need to be subscribed to the
 http://erlang.org/mailman/listinfo/erlang-questions[erlang-questions mailing list].

--- a/doc/src/guide/sphinx.asciidoc
+++ b/doc/src/guide/sphinx.asciidoc
@@ -2,15 +2,15 @@
 == Sphinx documentation
 
 Erlang.mk includes targets for running the
-http://www.sphinx-doc.org/[Sphinx documentation generator], which can produce
+https://www.sphinx-doc.org/[Sphinx documentation generator], which can produce
 documentation in various formats, like HTML, man pages, Texinfo, LaTeX, and
 others.
 
 === Writing Sphinx documentation
 
 Sphinx generates documentation from a set of
-http://www.sphinx-doc.org/en/stable/rest.html[reST] documents. There is
-a http://www.sphinx-doc.org/en/stable/tutorial.html[quick start guide] on
+https://www.sphinx-doc.org/en/stable/rest.html[reST] documents. There is
+a https://www.sphinx-doc.org/en/stable/tutorial.html[quick start guide] on
 Sphinx' website. For Erlang.mk, we'll set up a minimal environment instead.
 
 === Basic setup
@@ -89,7 +89,7 @@ though in this case you will need to manually call `make sphinx` or add the
 The `$(SPHINX_FORMATS)` variable lists formats to generate. By default only HTML
 is generated, but it can also build man pages or LaTeX documents which can later
 be converted to PDF. See the
-http://www.sphinx-doc.org/en/stable/invocation.html#cmdoption-sphinx-build-b[description of the `-b` option]
+https://www.sphinx-doc.org/en/stable/invocation.html#cmdoption-sphinx-build-b[description of the `-b` option]
 for `sphinx-build` for a list of known formats.
 
 Formats are by default generated to a directory called after the format
@@ -112,7 +112,7 @@ man_pages = [
 ----
 
 As the
-http://www.sphinx-doc.org/en/stable/config.html#options-for-manual-page-output[Sphinx documentation]
+https://www.sphinx-doc.org/en/stable/config.html#options-for-manual-page-output[Sphinx documentation]
 indicates, the structure is:
 
 * `doc_name` is the path to the man page's source (relative `$(SPHINX_SOURCE)`),

--- a/index/actordb_core.mk
+++ b/index/actordb_core.mk
@@ -1,7 +1,7 @@
 PACKAGES += actordb_core
 pkg_actordb_core_name = actordb_core
 pkg_actordb_core_description = ActorDB main source
-pkg_actordb_core_homepage = http://www.actordb.com/
+pkg_actordb_core_homepage = https://www.actordb.com/
 pkg_actordb_core_fetch = git
 pkg_actordb_core_repo = https://github.com/biokoda/actordb_core
 pkg_actordb_core_commit = master

--- a/index/actordb_thrift.mk
+++ b/index/actordb_thrift.mk
@@ -1,7 +1,7 @@
 PACKAGES += actordb_thrift
 pkg_actordb_thrift_name = actordb_thrift
 pkg_actordb_thrift_description = Thrift API for ActorDB
-pkg_actordb_thrift_homepage = http://www.actordb.com/
+pkg_actordb_thrift_homepage = https://www.actordb.com/
 pkg_actordb_thrift_fetch = git
 pkg_actordb_thrift_repo = https://github.com/biokoda/actordb_thrift
 pkg_actordb_thrift_commit = master

--- a/index/apns.mk
+++ b/index/apns.mk
@@ -1,7 +1,7 @@
 PACKAGES += apns
 pkg_apns_name = apns
 pkg_apns_description = Apple Push Notification Server for Erlang
-pkg_apns_homepage = http://inaka.github.com/apns4erl
+pkg_apns_homepage = https://inaka.github.com/apns4erl
 pkg_apns_fetch = git
 pkg_apns_repo = https://github.com/inaka/apns4erl
 pkg_apns_commit = master

--- a/index/bullet.mk
+++ b/index/bullet.mk
@@ -1,7 +1,7 @@
 PACKAGES += bullet
 pkg_bullet_name = bullet
 pkg_bullet_description = Simple, reliable, efficient streaming for Cowboy.
-pkg_bullet_homepage = http://ninenines.eu
+pkg_bullet_homepage = https://ninenines.eu
 pkg_bullet_fetch = git
 pkg_bullet_repo = https://github.com/ninenines/bullet
 pkg_bullet_commit = master

--- a/index/cloudi_core.mk
+++ b/index/cloudi_core.mk
@@ -1,7 +1,7 @@
 PACKAGES += cloudi_core
 pkg_cloudi_core_name = cloudi_core
 pkg_cloudi_core_description = CloudI internal service runtime
-pkg_cloudi_core_homepage = http://cloudi.org/
+pkg_cloudi_core_homepage = https://cloudi.org/
 pkg_cloudi_core_fetch = git
 pkg_cloudi_core_repo = https://github.com/CloudI/cloudi_core
 pkg_cloudi_core_commit = master

--- a/index/cloudi_service_api_requests.mk
+++ b/index/cloudi_service_api_requests.mk
@@ -1,7 +1,7 @@
 PACKAGES += cloudi_service_api_requests
 pkg_cloudi_service_api_requests_name = cloudi_service_api_requests
 pkg_cloudi_service_api_requests_description = CloudI Service API requests (JSON-RPC/Erlang-term support)
-pkg_cloudi_service_api_requests_homepage = http://cloudi.org/
+pkg_cloudi_service_api_requests_homepage = https://cloudi.org/
 pkg_cloudi_service_api_requests_fetch = git
 pkg_cloudi_service_api_requests_repo = https://github.com/CloudI/cloudi_service_api_requests
 pkg_cloudi_service_api_requests_commit = master

--- a/index/cloudi_service_db.mk
+++ b/index/cloudi_service_db.mk
@@ -1,7 +1,7 @@
 PACKAGES += cloudi_service_db
 pkg_cloudi_service_db_name = cloudi_service_db
 pkg_cloudi_service_db_description = CloudI Database (in-memory/testing/generic)
-pkg_cloudi_service_db_homepage = http://cloudi.org/
+pkg_cloudi_service_db_homepage = https://cloudi.org/
 pkg_cloudi_service_db_fetch = git
 pkg_cloudi_service_db_repo = https://github.com/CloudI/cloudi_service_db
 pkg_cloudi_service_db_commit = master

--- a/index/cloudi_service_db_cassandra.mk
+++ b/index/cloudi_service_db_cassandra.mk
@@ -1,7 +1,7 @@
 PACKAGES += cloudi_service_db_cassandra
 pkg_cloudi_service_db_cassandra_name = cloudi_service_db_cassandra
 pkg_cloudi_service_db_cassandra_description = Cassandra CloudI Service
-pkg_cloudi_service_db_cassandra_homepage = http://cloudi.org/
+pkg_cloudi_service_db_cassandra_homepage = https://cloudi.org/
 pkg_cloudi_service_db_cassandra_fetch = git
 pkg_cloudi_service_db_cassandra_repo = https://github.com/CloudI/cloudi_service_db_cassandra
 pkg_cloudi_service_db_cassandra_commit = master

--- a/index/cloudi_service_db_cassandra_cql.mk
+++ b/index/cloudi_service_db_cassandra_cql.mk
@@ -1,7 +1,7 @@
 PACKAGES += cloudi_service_db_cassandra_cql
 pkg_cloudi_service_db_cassandra_cql_name = cloudi_service_db_cassandra_cql
 pkg_cloudi_service_db_cassandra_cql_description = Cassandra CQL CloudI Service
-pkg_cloudi_service_db_cassandra_cql_homepage = http://cloudi.org/
+pkg_cloudi_service_db_cassandra_cql_homepage = https://cloudi.org/
 pkg_cloudi_service_db_cassandra_cql_fetch = git
 pkg_cloudi_service_db_cassandra_cql_repo = https://github.com/CloudI/cloudi_service_db_cassandra_cql
 pkg_cloudi_service_db_cassandra_cql_commit = master

--- a/index/cloudi_service_db_couchdb.mk
+++ b/index/cloudi_service_db_couchdb.mk
@@ -1,7 +1,7 @@
 PACKAGES += cloudi_service_db_couchdb
 pkg_cloudi_service_db_couchdb_name = cloudi_service_db_couchdb
 pkg_cloudi_service_db_couchdb_description = CouchDB CloudI Service
-pkg_cloudi_service_db_couchdb_homepage = http://cloudi.org/
+pkg_cloudi_service_db_couchdb_homepage = https://cloudi.org/
 pkg_cloudi_service_db_couchdb_fetch = git
 pkg_cloudi_service_db_couchdb_repo = https://github.com/CloudI/cloudi_service_db_couchdb
 pkg_cloudi_service_db_couchdb_commit = master

--- a/index/cloudi_service_db_elasticsearch.mk
+++ b/index/cloudi_service_db_elasticsearch.mk
@@ -1,7 +1,7 @@
 PACKAGES += cloudi_service_db_elasticsearch
 pkg_cloudi_service_db_elasticsearch_name = cloudi_service_db_elasticsearch
 pkg_cloudi_service_db_elasticsearch_description = elasticsearch CloudI Service
-pkg_cloudi_service_db_elasticsearch_homepage = http://cloudi.org/
+pkg_cloudi_service_db_elasticsearch_homepage = https://cloudi.org/
 pkg_cloudi_service_db_elasticsearch_fetch = git
 pkg_cloudi_service_db_elasticsearch_repo = https://github.com/CloudI/cloudi_service_db_elasticsearch
 pkg_cloudi_service_db_elasticsearch_commit = master

--- a/index/cloudi_service_db_memcached.mk
+++ b/index/cloudi_service_db_memcached.mk
@@ -1,7 +1,7 @@
 PACKAGES += cloudi_service_db_memcached
 pkg_cloudi_service_db_memcached_name = cloudi_service_db_memcached
 pkg_cloudi_service_db_memcached_description = memcached CloudI Service
-pkg_cloudi_service_db_memcached_homepage = http://cloudi.org/
+pkg_cloudi_service_db_memcached_homepage = https://cloudi.org/
 pkg_cloudi_service_db_memcached_fetch = git
 pkg_cloudi_service_db_memcached_repo = https://github.com/CloudI/cloudi_service_db_memcached
 pkg_cloudi_service_db_memcached_commit = master

--- a/index/cloudi_service_db_mysql.mk
+++ b/index/cloudi_service_db_mysql.mk
@@ -1,7 +1,7 @@
 PACKAGES += cloudi_service_db_mysql
 pkg_cloudi_service_db_mysql_name = cloudi_service_db_mysql
 pkg_cloudi_service_db_mysql_description = MySQL CloudI Service
-pkg_cloudi_service_db_mysql_homepage = http://cloudi.org/
+pkg_cloudi_service_db_mysql_homepage = https://cloudi.org/
 pkg_cloudi_service_db_mysql_fetch = git
 pkg_cloudi_service_db_mysql_repo = https://github.com/CloudI/cloudi_service_db_mysql
 pkg_cloudi_service_db_mysql_commit = master

--- a/index/cloudi_service_db_pgsql.mk
+++ b/index/cloudi_service_db_pgsql.mk
@@ -1,7 +1,7 @@
 PACKAGES += cloudi_service_db_pgsql
 pkg_cloudi_service_db_pgsql_name = cloudi_service_db_pgsql
 pkg_cloudi_service_db_pgsql_description = PostgreSQL CloudI Service
-pkg_cloudi_service_db_pgsql_homepage = http://cloudi.org/
+pkg_cloudi_service_db_pgsql_homepage = https://cloudi.org/
 pkg_cloudi_service_db_pgsql_fetch = git
 pkg_cloudi_service_db_pgsql_repo = https://github.com/CloudI/cloudi_service_db_pgsql
 pkg_cloudi_service_db_pgsql_commit = master

--- a/index/cloudi_service_db_riak.mk
+++ b/index/cloudi_service_db_riak.mk
@@ -1,7 +1,7 @@
 PACKAGES += cloudi_service_db_riak
 pkg_cloudi_service_db_riak_name = cloudi_service_db_riak
 pkg_cloudi_service_db_riak_description = Riak CloudI Service
-pkg_cloudi_service_db_riak_homepage = http://cloudi.org/
+pkg_cloudi_service_db_riak_homepage = https://cloudi.org/
 pkg_cloudi_service_db_riak_fetch = git
 pkg_cloudi_service_db_riak_repo = https://github.com/CloudI/cloudi_service_db_riak
 pkg_cloudi_service_db_riak_commit = master

--- a/index/cloudi_service_db_tokyotyrant.mk
+++ b/index/cloudi_service_db_tokyotyrant.mk
@@ -1,7 +1,7 @@
 PACKAGES += cloudi_service_db_tokyotyrant
 pkg_cloudi_service_db_tokyotyrant_name = cloudi_service_db_tokyotyrant
 pkg_cloudi_service_db_tokyotyrant_description = Tokyo Tyrant CloudI Service
-pkg_cloudi_service_db_tokyotyrant_homepage = http://cloudi.org/
+pkg_cloudi_service_db_tokyotyrant_homepage = https://cloudi.org/
 pkg_cloudi_service_db_tokyotyrant_fetch = git
 pkg_cloudi_service_db_tokyotyrant_repo = https://github.com/CloudI/cloudi_service_db_tokyotyrant
 pkg_cloudi_service_db_tokyotyrant_commit = master

--- a/index/cloudi_service_filesystem.mk
+++ b/index/cloudi_service_filesystem.mk
@@ -1,7 +1,7 @@
 PACKAGES += cloudi_service_filesystem
 pkg_cloudi_service_filesystem_name = cloudi_service_filesystem
 pkg_cloudi_service_filesystem_description = Filesystem CloudI Service
-pkg_cloudi_service_filesystem_homepage = http://cloudi.org/
+pkg_cloudi_service_filesystem_homepage = https://cloudi.org/
 pkg_cloudi_service_filesystem_fetch = git
 pkg_cloudi_service_filesystem_repo = https://github.com/CloudI/cloudi_service_filesystem
 pkg_cloudi_service_filesystem_commit = master

--- a/index/cloudi_service_http_client.mk
+++ b/index/cloudi_service_http_client.mk
@@ -1,7 +1,7 @@
 PACKAGES += cloudi_service_http_client
 pkg_cloudi_service_http_client_name = cloudi_service_http_client
 pkg_cloudi_service_http_client_description = HTTP client CloudI Service
-pkg_cloudi_service_http_client_homepage = http://cloudi.org/
+pkg_cloudi_service_http_client_homepage = https://cloudi.org/
 pkg_cloudi_service_http_client_fetch = git
 pkg_cloudi_service_http_client_repo = https://github.com/CloudI/cloudi_service_http_client
 pkg_cloudi_service_http_client_commit = master

--- a/index/cloudi_service_http_cowboy.mk
+++ b/index/cloudi_service_http_cowboy.mk
@@ -1,7 +1,7 @@
 PACKAGES += cloudi_service_http_cowboy
 pkg_cloudi_service_http_cowboy_name = cloudi_service_http_cowboy
 pkg_cloudi_service_http_cowboy_description = cowboy HTTP/HTTPS CloudI Service
-pkg_cloudi_service_http_cowboy_homepage = http://cloudi.org/
+pkg_cloudi_service_http_cowboy_homepage = https://cloudi.org/
 pkg_cloudi_service_http_cowboy_fetch = git
 pkg_cloudi_service_http_cowboy_repo = https://github.com/CloudI/cloudi_service_http_cowboy
 pkg_cloudi_service_http_cowboy_commit = master

--- a/index/cloudi_service_http_elli.mk
+++ b/index/cloudi_service_http_elli.mk
@@ -1,7 +1,7 @@
 PACKAGES += cloudi_service_http_elli
 pkg_cloudi_service_http_elli_name = cloudi_service_http_elli
 pkg_cloudi_service_http_elli_description = elli HTTP CloudI Service
-pkg_cloudi_service_http_elli_homepage = http://cloudi.org/
+pkg_cloudi_service_http_elli_homepage = https://cloudi.org/
 pkg_cloudi_service_http_elli_fetch = git
 pkg_cloudi_service_http_elli_repo = https://github.com/CloudI/cloudi_service_http_elli
 pkg_cloudi_service_http_elli_commit = master

--- a/index/cloudi_service_map_reduce.mk
+++ b/index/cloudi_service_map_reduce.mk
@@ -1,7 +1,7 @@
 PACKAGES += cloudi_service_map_reduce
 pkg_cloudi_service_map_reduce_name = cloudi_service_map_reduce
 pkg_cloudi_service_map_reduce_description = Map/Reduce CloudI Service
-pkg_cloudi_service_map_reduce_homepage = http://cloudi.org/
+pkg_cloudi_service_map_reduce_homepage = https://cloudi.org/
 pkg_cloudi_service_map_reduce_fetch = git
 pkg_cloudi_service_map_reduce_repo = https://github.com/CloudI/cloudi_service_map_reduce
 pkg_cloudi_service_map_reduce_commit = master

--- a/index/cloudi_service_oauth1.mk
+++ b/index/cloudi_service_oauth1.mk
@@ -1,7 +1,7 @@
 PACKAGES += cloudi_service_oauth1
 pkg_cloudi_service_oauth1_name = cloudi_service_oauth1
 pkg_cloudi_service_oauth1_description = OAuth v1.0 CloudI Service
-pkg_cloudi_service_oauth1_homepage = http://cloudi.org/
+pkg_cloudi_service_oauth1_homepage = https://cloudi.org/
 pkg_cloudi_service_oauth1_fetch = git
 pkg_cloudi_service_oauth1_repo = https://github.com/CloudI/cloudi_service_oauth1
 pkg_cloudi_service_oauth1_commit = master

--- a/index/cloudi_service_queue.mk
+++ b/index/cloudi_service_queue.mk
@@ -1,7 +1,7 @@
 PACKAGES += cloudi_service_queue
 pkg_cloudi_service_queue_name = cloudi_service_queue
 pkg_cloudi_service_queue_description = Persistent Queue Service
-pkg_cloudi_service_queue_homepage = http://cloudi.org/
+pkg_cloudi_service_queue_homepage = https://cloudi.org/
 pkg_cloudi_service_queue_fetch = git
 pkg_cloudi_service_queue_repo = https://github.com/CloudI/cloudi_service_queue
 pkg_cloudi_service_queue_commit = master

--- a/index/cloudi_service_quorum.mk
+++ b/index/cloudi_service_quorum.mk
@@ -1,7 +1,7 @@
 PACKAGES += cloudi_service_quorum
 pkg_cloudi_service_quorum_name = cloudi_service_quorum
 pkg_cloudi_service_quorum_description = CloudI Quorum Service
-pkg_cloudi_service_quorum_homepage = http://cloudi.org/
+pkg_cloudi_service_quorum_homepage = https://cloudi.org/
 pkg_cloudi_service_quorum_fetch = git
 pkg_cloudi_service_quorum_repo = https://github.com/CloudI/cloudi_service_quorum
 pkg_cloudi_service_quorum_commit = master

--- a/index/cloudi_service_router.mk
+++ b/index/cloudi_service_router.mk
@@ -1,7 +1,7 @@
 PACKAGES += cloudi_service_router
 pkg_cloudi_service_router_name = cloudi_service_router
 pkg_cloudi_service_router_description = CloudI Router Service
-pkg_cloudi_service_router_homepage = http://cloudi.org/
+pkg_cloudi_service_router_homepage = https://cloudi.org/
 pkg_cloudi_service_router_fetch = git
 pkg_cloudi_service_router_repo = https://github.com/CloudI/cloudi_service_router
 pkg_cloudi_service_router_commit = master

--- a/index/cloudi_service_tcp.mk
+++ b/index/cloudi_service_tcp.mk
@@ -1,7 +1,7 @@
 PACKAGES += cloudi_service_tcp
 pkg_cloudi_service_tcp_name = cloudi_service_tcp
 pkg_cloudi_service_tcp_description = TCP CloudI Service
-pkg_cloudi_service_tcp_homepage = http://cloudi.org/
+pkg_cloudi_service_tcp_homepage = https://cloudi.org/
 pkg_cloudi_service_tcp_fetch = git
 pkg_cloudi_service_tcp_repo = https://github.com/CloudI/cloudi_service_tcp
 pkg_cloudi_service_tcp_commit = master

--- a/index/cloudi_service_timers.mk
+++ b/index/cloudi_service_timers.mk
@@ -1,7 +1,7 @@
 PACKAGES += cloudi_service_timers
 pkg_cloudi_service_timers_name = cloudi_service_timers
 pkg_cloudi_service_timers_description = Timers CloudI Service
-pkg_cloudi_service_timers_homepage = http://cloudi.org/
+pkg_cloudi_service_timers_homepage = https://cloudi.org/
 pkg_cloudi_service_timers_fetch = git
 pkg_cloudi_service_timers_repo = https://github.com/CloudI/cloudi_service_timers
 pkg_cloudi_service_timers_commit = master

--- a/index/cloudi_service_udp.mk
+++ b/index/cloudi_service_udp.mk
@@ -1,7 +1,7 @@
 PACKAGES += cloudi_service_udp
 pkg_cloudi_service_udp_name = cloudi_service_udp
 pkg_cloudi_service_udp_description = UDP CloudI Service
-pkg_cloudi_service_udp_homepage = http://cloudi.org/
+pkg_cloudi_service_udp_homepage = https://cloudi.org/
 pkg_cloudi_service_udp_fetch = git
 pkg_cloudi_service_udp_repo = https://github.com/CloudI/cloudi_service_udp
 pkg_cloudi_service_udp_commit = master

--- a/index/cloudi_service_validate.mk
+++ b/index/cloudi_service_validate.mk
@@ -1,7 +1,7 @@
 PACKAGES += cloudi_service_validate
 pkg_cloudi_service_validate_name = cloudi_service_validate
 pkg_cloudi_service_validate_description = CloudI Validate Service
-pkg_cloudi_service_validate_homepage = http://cloudi.org/
+pkg_cloudi_service_validate_homepage = https://cloudi.org/
 pkg_cloudi_service_validate_fetch = git
 pkg_cloudi_service_validate_repo = https://github.com/CloudI/cloudi_service_validate
 pkg_cloudi_service_validate_commit = master

--- a/index/cloudi_service_zeromq.mk
+++ b/index/cloudi_service_zeromq.mk
@@ -1,7 +1,7 @@
 PACKAGES += cloudi_service_zeromq
 pkg_cloudi_service_zeromq_name = cloudi_service_zeromq
 pkg_cloudi_service_zeromq_description = ZeroMQ CloudI Service
-pkg_cloudi_service_zeromq_homepage = http://cloudi.org/
+pkg_cloudi_service_zeromq_homepage = https://cloudi.org/
 pkg_cloudi_service_zeromq_fetch = git
 pkg_cloudi_service_zeromq_repo = https://github.com/CloudI/cloudi_service_zeromq
 pkg_cloudi_service_zeromq_commit = master

--- a/index/cowboy.mk
+++ b/index/cowboy.mk
@@ -1,7 +1,7 @@
 PACKAGES += cowboy
 pkg_cowboy_name = cowboy
 pkg_cowboy_description = Small, fast and modular HTTP server.
-pkg_cowboy_homepage = http://ninenines.eu
+pkg_cowboy_homepage = https://ninenines.eu
 pkg_cowboy_fetch = git
 pkg_cowboy_repo = https://github.com/ninenines/cowboy
 pkg_cowboy_commit = 1.0.4

--- a/index/cowlib.mk
+++ b/index/cowlib.mk
@@ -1,7 +1,7 @@
 PACKAGES += cowlib
 pkg_cowlib_name = cowlib
 pkg_cowlib_description = Support library for manipulating Web protocols.
-pkg_cowlib_homepage = http://ninenines.eu
+pkg_cowlib_homepage = https://ninenines.eu
 pkg_cowlib_fetch = git
 pkg_cowlib_repo = https://github.com/ninenines/cowlib
 pkg_cowlib_commit = 1.0.2

--- a/index/edis.mk
+++ b/index/edis.mk
@@ -1,7 +1,7 @@
 PACKAGES += edis
 pkg_edis_name = edis
 pkg_edis_description = An Erlang implementation of Redis KV Store
-pkg_edis_homepage = http://inaka.github.com/edis/
+pkg_edis_homepage = https://inaka.github.com/edis/
 pkg_edis_fetch = git
 pkg_edis_repo = https://github.com/inaka/edis
 pkg_edis_commit = master

--- a/index/erldb.mk
+++ b/index/erldb.mk
@@ -1,7 +1,7 @@
 PACKAGES += erldb
 pkg_erldb_name = erldb
 pkg_erldb_description = ORM (Object-relational mapping) application implemented in Erlang
-pkg_erldb_homepage = http://erldb.org
+pkg_erldb_homepage = https://erldb.org
 pkg_erldb_fetch = git
 pkg_erldb_repo = https://github.com/erldb/erldb
 pkg_erldb_commit = master

--- a/index/exec.mk
+++ b/index/exec.mk
@@ -1,7 +1,7 @@
 PACKAGES += exec
 pkg_exec_name = erlexec
 pkg_exec_description = Execute and control OS processes from Erlang/OTP.
-pkg_exec_homepage = http://saleyn.github.com/erlexec
+pkg_exec_homepage = https://saleyn.github.com/erlexec
 pkg_exec_fetch = git
 pkg_exec_repo = https://github.com/saleyn/erlexec
 pkg_exec_commit = master

--- a/index/fix.mk
+++ b/index/fix.mk
@@ -1,6 +1,6 @@
 PACKAGES += fix
 pkg_fix_name = fix
-pkg_fix_description = http://fixprotocol.org/ implementation.
+pkg_fix_description = https://fixtrading.org implementation.
 pkg_fix_homepage = https://github.com/maxlapshin/fix
 pkg_fix_fetch = git
 pkg_fix_repo = https://github.com/maxlapshin/fix

--- a/index/lasp.mk
+++ b/index/lasp.mk
@@ -1,7 +1,7 @@
 PACKAGES += lasp
 pkg_lasp_name = lasp
 pkg_lasp_description = A Language for Distributed, Eventually Consistent Computations
-pkg_lasp_homepage = http://lasp-lang.org/
+pkg_lasp_homepage = https://lasp-lang.org/
 pkg_lasp_fetch = git
 pkg_lasp_repo = https://github.com/lasp-lang/lasp
 pkg_lasp_commit = master

--- a/index/live.mk
+++ b/index/live.mk
@@ -1,7 +1,7 @@
 PACKAGES += live
 pkg_live_name = live
 pkg_live_description = Automated module and configuration reloader.
-pkg_live_homepage = http://ninenines.eu
+pkg_live_homepage = https://ninenines.eu
 pkg_live_fetch = git
 pkg_live_repo = https://github.com/ninenines/live
 pkg_live_commit = master

--- a/index/observer_cli.mk
+++ b/index/observer_cli.mk
@@ -1,7 +1,7 @@
 PACKAGES += observer_cli
 pkg_observer_cli_name = observer_cli
 pkg_observer_cli_description = Visualize Erlang/Elixir Nodes On The Command Line
-pkg_observer_cli_homepage = http://zhongwencool.github.io/observer_cli
+pkg_observer_cli_homepage = https://zhongwencool.github.io/observer_cli
 pkg_observer_cli_fetch = git
 pkg_observer_cli_repo = https://github.com/zhongwencool/observer_cli
 pkg_observer_cli_commit = master

--- a/index/ranch.mk
+++ b/index/ranch.mk
@@ -1,7 +1,7 @@
 PACKAGES += ranch
 pkg_ranch_name = ranch
 pkg_ranch_description = Socket acceptor pool for TCP protocols.
-pkg_ranch_homepage = http://ninenines.eu
+pkg_ranch_homepage = https://ninenines.eu
 pkg_ranch_fetch = git
 pkg_ranch_repo = https://github.com/ninenines/ranch
 pkg_ranch_commit = 1.2.1

--- a/index/rebar.mk
+++ b/index/rebar.mk
@@ -1,7 +1,7 @@
 PACKAGES += rebar
 pkg_rebar_name = rebar
 pkg_rebar_description = Erlang build tool that makes it easy to compile and test Erlang applications, port drivers and releases.
-pkg_rebar_homepage = http://www.rebar3.org
+pkg_rebar_homepage = https://www.rebar3.org
 pkg_rebar_fetch = git
 pkg_rebar_repo = https://github.com/rebar/rebar3
 pkg_rebar_commit = master

--- a/index/resource_discovery.mk
+++ b/index/resource_discovery.mk
@@ -1,7 +1,7 @@
 PACKAGES += resource_discovery
 pkg_resource_discovery_name = resource_discovery
 pkg_resource_discovery_description = An application used to dynamically discover resources present in an Erlang node cluster.
-pkg_resource_discovery_homepage = http://erlware.org/
+pkg_resource_discovery_homepage = https://erlware.org/
 pkg_resource_discovery_fetch = git
 pkg_resource_discovery_repo = https://github.com/erlware/resource_discovery
 pkg_resource_discovery_commit = master

--- a/index/service.mk
+++ b/index/service.mk
@@ -1,7 +1,7 @@
 PACKAGES += service
 pkg_service_name = service
 pkg_service_description = A minimal Erlang behavior for creating CloudI internal services
-pkg_service_homepage = http://cloudi.org/
+pkg_service_homepage = https://cloudi.org/
 pkg_service_fetch = git
 pkg_service_repo = https://github.com/CloudI/service
 pkg_service_commit = master

--- a/index/sheriff.mk
+++ b/index/sheriff.mk
@@ -1,7 +1,7 @@
 PACKAGES += sheriff
 pkg_sheriff_name = sheriff
 pkg_sheriff_description = Parse transform for type based validation.
-pkg_sheriff_homepage = http://ninenines.eu
+pkg_sheriff_homepage = https://ninenines.eu
 pkg_sheriff_fetch = git
 pkg_sheriff_repo = https://github.com/extend/sheriff
 pkg_sheriff_commit = master

--- a/index/trails.mk
+++ b/index/trails.mk
@@ -1,7 +1,7 @@
 PACKAGES += trails
 pkg_trails_name = trails
 pkg_trails_description = A couple of improvements over Cowboy Routes
-pkg_trails_homepage = http://inaka.github.io/cowboy-trails/
+pkg_trails_homepage = https://inaka.github.io/cowboy-trails/
 pkg_trails_fetch = git
 pkg_trails_repo = https://github.com/inaka/cowboy-trails
 pkg_trails_commit = master

--- a/index/wrangler.mk
+++ b/index/wrangler.mk
@@ -1,7 +1,7 @@
 PACKAGES += wrangler
 pkg_wrangler_name = wrangler
 pkg_wrangler_description = Import of the Wrangler svn repository.
-pkg_wrangler_homepage = http://www.cs.kent.ac.uk/projects/wrangler/Home.html
+pkg_wrangler_homepage = https://www.cs.kent.ac.uk/projects/wrangler/Home.html
 pkg_wrangler_fetch = git
 pkg_wrangler_repo = https://github.com/RefactoringTools/wrangler
 pkg_wrangler_commit = master

--- a/test/Makefile
+++ b/test/Makefile
@@ -41,7 +41,7 @@ endif
 # and maybe sleep during test execution.
 #
 # Also see:
-# * http://arstechnica.com/apple/2011/07/mac-os-x-10-7/12/#hfs-problems
+# * https://arstechnica.com/apple/2011/07/mac-os-x-10-7/12/#hfs-problems
 # * https://apple.stackexchange.com/questions/51650/linus-torvalds-and-the-os-x-filesystem
 
 ifeq ($(shell touch a; sleep 0.01; touch b; sleep 0.01; touch c; test c -nt b -a b -nt a; echo $$?; rm a b c),1)


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://asciidoc.org/ (200) with 2 occurrences could not be migrated:  
   ([https](https://asciidoc.org/) result SSLHandshakeException).
* http://asciidoc.org/userguide.html (200) with 1 occurrences could not be migrated:  
   ([https](https://asciidoc.org/userguide.html) result SSLHandshakeException).
* http://blog.listincomprehension.com/search/label/procket (200) with 1 occurrences could not be migrated:  
   ([https](https://blog.listincomprehension.com/search/label/procket) result ClosedChannelException).
* http://dblatex.sourceforge.net/ (200) with 1 occurrences could not be migrated:  
   ([https](https://dblatex.sourceforge.net/) result AnnotatedConnectException).
* http://dozzie.jarowit.net/trac/wiki/TOML (200) with 1 occurrences could not be migrated:  
   ([https](https://dozzie.jarowit.net/trac/wiki/TOML) result SSLHandshakeException).
* http://dozzie.jarowit.net/trac/wiki/subproc (200) with 1 occurrences could not be migrated:  
   ([https](https://dozzie.jarowit.net/trac/wiki/subproc) result SSLHandshakeException).
* http://e2project.org (200) with 1 occurrences could not be migrated:  
   ([https](https://e2project.org) result AnnotatedConnectException).
* http://efene.org/ (200) with 1 occurrences could not be migrated:  
   ([https](https://efene.org/) result SSLHandshakeException).
* http://erlang.org/doc/man/appup.html (200) with 1 occurrences could not be migrated:  
   ([https](https://erlang.org/doc/man/appup.html) result ConnectTimeoutException).
* http://erlang.org/doc/man/asn1ct.html (200) with 1 occurrences could not be migrated:  
   ([https](https://erlang.org/doc/man/asn1ct.html) result ConnectTimeoutException).
* http://erlang.org/mailman/listinfo/erlang-questions (200) with 1 occurrences could not be migrated:  
   ([https](https://erlang.org/mailman/listinfo/erlang-questions) result ConnectTimeoutException).
* http://lfe.io/ (200) with 1 occurrences could not be migrated:  
   ([https](https://lfe.io/) result SSLHandshakeException).
* http://nitrogenproject.com/ (200) with 2 occurrences could not be migrated:  
   ([https](https://nitrogenproject.com/) result ConnectTimeoutException).
* http://proper.softlab.ntua.gr (200) with 1 occurrences could not be migrated:  
   ([https](https://proper.softlab.ntua.gr) result SSLHandshakeException).
* http://xmlsoft.org/XSLT/xsltproc2.html (200) with 1 occurrences could not be migrated:  
   ([https](https://xmlsoft.org/XSLT/xsltproc2.html) result SSLHandshakeException).
* http://yaws.hyber.org (200) with 1 occurrences could not be migrated:  
   ([https](https://yaws.hyber.org) result AnnotatedConnectException).
* http://choven.ca (503) with 1 occurrences could not be migrated:  
   ([https](https://choven.ca) result ConnectTimeoutException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://fixprotocol.org/ (301) with 1 occurrences migrated to:  
  https://fixtrading.org ([https](https://fixprotocol.org/) result SSLHandshakeException).
* http://erldb.org (UnknownHostException) with 1 occurrences migrated to:  
  https://erldb.org ([https](https://erldb.org) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://cloudi.org/ with 27 occurrences migrated to:  
  https://cloudi.org/ ([https](https://cloudi.org/) result 200).
* http://elixir-lang.org/ with 1 occurrences migrated to:  
  https://elixir-lang.org/ ([https](https://elixir-lang.org/) result 200).
* http://elixir-lang.org/getting-started/mix-otp/introduction-to-mix.html with 1 occurrences migrated to:  
  https://elixir-lang.org/getting-started/mix-otp/introduction-to-mix.html ([https](https://elixir-lang.org/getting-started/mix-otp/introduction-to-mix.html) result 200).
* http://erlang.mk/ with 1 occurrences migrated to:  
  https://erlang.mk/ ([https](https://erlang.mk/) result 200).
* http://erlang.mk/guide/ with 2 occurrences migrated to:  
  https://erlang.mk/guide/ ([https](https://erlang.mk/guide/) result 200).
* http://erlang.mk/guide/getting_started.html with 1 occurrences migrated to:  
  https://erlang.mk/guide/getting_started.html ([https](https://erlang.mk/guide/getting_started.html) result 200).
* http://erlang.mk/guide/installation.html with 2 occurrences migrated to:  
  https://erlang.mk/guide/installation.html ([https](https://erlang.mk/guide/installation.html) result 200).
* http://erlware.org/ with 1 occurrences migrated to:  
  https://erlware.org/ ([https](https://erlware.org/) result 200).
* http://inaka.github.io/cowboy-trails/ with 1 occurrences migrated to:  
  https://inaka.github.io/cowboy-trails/ ([https](https://inaka.github.io/cowboy-trails/) result 200).
* http://ninenines.eu with 7 occurrences migrated to:  
  https://ninenines.eu ([https](https://ninenines.eu) result 200).
* http://www.actordb.com/ with 2 occurrences migrated to:  
  https://www.actordb.com/ ([https](https://www.actordb.com/) result 200).
* http://www.cs.kent.ac.uk/projects/wrangler/Home.html with 1 occurrences migrated to:  
  https://www.cs.kent.ac.uk/projects/wrangler/Home.html ([https](https://www.cs.kent.ac.uk/projects/wrangler/Home.html) result 200).
* http://www.erlang.org/downloads with 1 occurrences migrated to:  
  https://www.erlang.org/downloads ([https](https://www.erlang.org/downloads) result 200).
* http://www.rebar3.org with 1 occurrences migrated to:  
  https://www.rebar3.org ([https](https://www.rebar3.org) result 200).
* http://arstechnica.com/apple/2011/07/mac-os-x-10-7/12/ with 1 occurrences migrated to:  
  https://arstechnica.com/apple/2011/07/mac-os-x-10-7/12/ ([https](https://arstechnica.com/apple/2011/07/mac-os-x-10-7/12/) result 301).
* http://inaka.github.com/apns4erl with 1 occurrences migrated to:  
  https://inaka.github.com/apns4erl ([https](https://inaka.github.com/apns4erl) result 301).
* http://inaka.github.com/edis/ with 1 occurrences migrated to:  
  https://inaka.github.com/edis/ ([https](https://inaka.github.com/edis/) result 301).
* http://lasp-lang.org/ with 1 occurrences migrated to:  
  https://lasp-lang.org/ ([https](https://lasp-lang.org/) result 301).
* http://msys2.github.io with 1 occurrences migrated to:  
  https://msys2.github.io ([https](https://msys2.github.io) result 301).
* http://saleyn.github.com/erlexec with 1 occurrences migrated to:  
  https://saleyn.github.com/erlexec ([https](https://saleyn.github.com/erlexec) result 301).
* http://www.erlang.org/doc/apps/common_test/run_test_chapter.html with 1 occurrences migrated to:  
  https://www.erlang.org/doc/apps/common_test/run_test_chapter.html ([https](https://www.erlang.org/doc/apps/common_test/run_test_chapter.html) result 301).
* http://www.erlang.org/doc/apps/common_test/write_test_chapter.html with 1 occurrences migrated to:  
  https://www.erlang.org/doc/apps/common_test/write_test_chapter.html ([https](https://www.erlang.org/doc/apps/common_test/write_test_chapter.html) result 301).
* http://www.erlang.org/doc/apps/edoc/chapter.html with 1 occurrences migrated to:  
  https://www.erlang.org/doc/apps/edoc/chapter.html ([https](https://www.erlang.org/doc/apps/edoc/chapter.html) result 301).
* http://www.erlang.org/doc/apps/eunit/chapter.html with 1 occurrences migrated to:  
  https://www.erlang.org/doc/apps/eunit/chapter.html ([https](https://www.erlang.org/doc/apps/eunit/chapter.html) result 301).
* http://www.erlang.org/doc/man/app.html with 1 occurrences migrated to:  
  https://www.erlang.org/doc/man/app.html ([https](https://www.erlang.org/doc/man/app.html) result 301).
* http://www.erlang.org/doc/man/edoc.html with 1 occurrences migrated to:  
  https://www.erlang.org/doc/man/edoc.html ([https](https://www.erlang.org/doc/man/edoc.html) result 301).
* http://www.erlang.org/doc/man/erlc.html with 1 occurrences migrated to:  
  https://www.erlang.org/doc/man/erlc.html ([https](https://www.erlang.org/doc/man/erlc.html) result 301).
* http://www.erlang.org/doc/man/escript.html with 1 occurrences migrated to:  
  https://www.erlang.org/doc/man/escript.html ([https](https://www.erlang.org/doc/man/escript.html) result 301).
* http://www.erlang.org/doc/man/eunit.html with 1 occurrences migrated to:  
  https://www.erlang.org/doc/man/eunit.html ([https](https://www.erlang.org/doc/man/eunit.html) result 301).
* http://www.erlang.org/download.html with 2 occurrences migrated to:  
  https://www.erlang.org/download.html ([https](https://www.erlang.org/download.html) result 301).
* http://zhongwencool.github.io/observer_cli with 1 occurrences migrated to:  
  https://zhongwencool.github.io/observer_cli ([https](https://zhongwencool.github.io/observer_cli) result 301).
* http://sourceforge.net/projects/msys2/files/Base/x86_64/msys2-base-x86_64-20150512.tar.xz/download with 1 occurrences migrated to:  
  https://sourceforge.net/projects/msys2/files/Base/x86_64/msys2-base-x86_64-20150512.tar.xz/download ([https](https://sourceforge.net/projects/msys2/files/Base/x86_64/msys2-base-x86_64-20150512.tar.xz/download) result 302).
* http://www.sphinx-doc.org/ with 1 occurrences migrated to:  
  https://www.sphinx-doc.org/ ([https](https://www.sphinx-doc.org/) result 302).
* http://www.sphinx-doc.org/en/stable/config.html with 1 occurrences migrated to:  
  https://www.sphinx-doc.org/en/stable/config.html ([https](https://www.sphinx-doc.org/en/stable/config.html) result 302).
* http://www.sphinx-doc.org/en/stable/invocation.html with 1 occurrences migrated to:  
  https://www.sphinx-doc.org/en/stable/invocation.html ([https](https://www.sphinx-doc.org/en/stable/invocation.html) result 302).
* http://www.sphinx-doc.org/en/stable/rest.html with 1 occurrences migrated to:  
  https://www.sphinx-doc.org/en/stable/rest.html ([https](https://www.sphinx-doc.org/en/stable/rest.html) result 302).
* http://www.sphinx-doc.org/en/stable/tutorial.html with 1 occurrences migrated to:  
  https://www.sphinx-doc.org/en/stable/tutorial.html ([https](https://www.sphinx-doc.org/en/stable/tutorial.html) result 302).